### PR TITLE
handline duplicate resources

### DIFF
--- a/grails-app/services/org/grails/plugin/resource/ResourceService.groovy
+++ b/grails-app/services/org/grails/plugin/resource/ResourceService.groovy
@@ -397,9 +397,7 @@ class ResourceService implements InitializingBean {
         }
         
         if (!adHocResource && findResourceForURI(r.sourceUrl)) {
-            throw new IllegalArgumentException(
-                "Skipping prepare resource for [${r.sourceUrl}] - You have multiple modules declaring this same resource."
-            )
+            log.warn "Skipping prepare resource for [${r.sourceUrl}] - You have multiple modules declaring this same resource."
         }
 
         def uri = r.sourceUrl


### PR DESCRIPTION
With a recent build of the resources plugin there's some trouble when using in combination with e.g. the jquery-ui plugin. The latter has duplicate resources (see "js" in http://svn.codehaus.org/grails-plugins/grails-jquery-ui/trunk/grails-app/conf/JqueryUiPluginResources.groovy) causing an exception during resource processing and therefore skip handling of remaining resources.
