### PR TITLE
Correcting small error in section 6.1 of the docs

### DIFF
--- a/src/docs/guide/6.1 Defining a mapper.gdoc
+++ b/src/docs/guide/6.1 Defining a mapper.gdoc
@@ -21,7 +21,7 @@ class TestResourceMapper {
 }
 {code}
 
-The only method a mapper must implement is *map(resource, config)* which is passed the [ResourceMeta|http://github.com/grails-plugins/grails-resources/blob/master/src/groovy/org/grails/plugin/resource/ResourceMeta.groovy] object that represents the resource and the mapper-specific config variables pulled out of grails.resources.<mappername>.
+The only method a mapper must implement is *map(resource, config)* which is passed the [ResourceMeta|http://github.com/grails-plugins/grails-resources/blob/master/src/groovy/org/grails/plugin/resource/ResourceMeta.groovy] object that represents the resource and the mapper-specific config variables pulled out of grails.resources.mappers.<mappername>.
 
 This method can do whatever it needs to the resource's file, provided it calls the updateActualUrlFromProcessedFile() method if the resource moves, unless you patch ResourceMeta.actualUrl manually.
 


### PR DESCRIPTION
Doc section 6.1 states that mapper specific config is pulled from grails.resources.<mappername>. This is wrong. It should be grails.resources.mappers.<mappername>
