### PR TITLE
Base Url mapper and spock tests

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -34,5 +34,8 @@ grails.project.dependency.resolution = {
         build(":release:1.0.0.RC3") {
             export = false
         }
+        test(":spock:0.5-groovy-1.7"){
+            export = false
+        }
     }
 }

--- a/grails-app/resourceMappers/org/grails/plugin/resource/BaseUrlResourceMapper.groovy
+++ b/grails-app/resourceMappers/org/grails/plugin/resource/BaseUrlResourceMapper.groovy
@@ -1,0 +1,39 @@
+package org.grails.plugin.resource.mapper
+
+import org.grails.plugin.resource.mapper.MapperPhase
+
+class BaseUrlResourceMapper {
+
+    static priority = 0
+    static phase = MapperPhase.ABSOLUTISATION
+
+    def map(resource, config) {
+
+        println 'BaseUrlResourceMapper' + config
+
+
+        if( config.enabled ){
+
+			def url
+
+            println config
+
+			if( resource.module?.name && config.moduleUrls[ resource.module.name ] ){
+				url = config.moduleUrls[ resource.module.name ]
+			}
+
+			if( !url ){
+				url = config.baseUrl
+			}
+
+			if( url ){
+				if( url.endsWith('/') ){
+					url = url[0..-2]
+				}
+				resource.linkOverride = url + resource.linkUrl
+			}
+		}
+
+    }
+
+}

--- a/src/groovy/org/grails/plugin/resource/mapper/ResourceMapper.groovy
+++ b/src/groovy/org/grails/plugin/resource/mapper/ResourceMapper.groovy
@@ -95,7 +95,7 @@ class ResourceMapper {
     ResourceMapper(artefact, mappersConfig) {
         this.artefact = artefact
         this.config = mappersConfig[getName()]
-        
+
         // @todo why are we doing this, why isn't logging plugin doing it?
         // Even though we load after logging, it seems to not apply it to our artefacts
         log = LoggerFactory.getLogger('org.grails.plugin.resource.mapper.' + getName())

--- a/test/unit/org/grails/plugin/resource/BaseUrlResourceMapperSpec.groovy
+++ b/test/unit/org/grails/plugin/resource/BaseUrlResourceMapperSpec.groovy
@@ -1,0 +1,53 @@
+package org.grails.plugin.resource
+
+import grails.plugin.spock.UnitSpec
+
+class BaseUrlResourceMapperSpec extends UnitSpec{
+
+    def mapper
+
+    def setup(){
+        mapper = new BaseUrlResourceMapper()
+    }
+
+    def "test that mappers are configured correctly"(){
+        setup:
+            def resource = [ linkUrl : 'images.jpg' ]
+            def config = [ enabled: true, baseUrl: 'http://www.google.com/' ]
+        when:
+            mapper.map( resource, config )
+        then:
+            resource.linkOverride == 'http://www.google.com/images.jpg'
+    }
+
+    def "when mappers are disabled, links are not processed"(){
+        setup:
+            def resource = [ linkUrl : 'images.jpg' ]
+            def config = [ enabled: false, baseUrl: 'http://www.google.com/' ]
+        when:
+            mapper.map( resource, config )
+        then:
+            resource.linkOverride == null
+    }
+
+    def "a resource can set a unique url based on module name"(){
+        setup:
+            def resource = [ linkUrl : 'images.jpg', module: [ name: 'uno'] ]
+            def config = [ enabled: true, baseUrl:'http://www.google.com/', moduleUrls : [ uno: 'http://uno.com/' ] ]
+        when:
+            mapper.map( resource, config )
+        then:
+            resource.linkOverride == 'http://uno.com/images.jpg'
+    }
+
+    def "a resource with no modules default to base url"(){
+        setup:
+            def resource = [ linkUrl : 'images.jpg', module: [ name: 'uno'] ]
+            def config = [ enabled: true, baseUrl:'http://www.google.com/', moduleUrls : [ dos: 'http://dos.com/' ] ]
+        when:
+            mapper.map( resource, config )
+        then:
+            resource.linkOverride == 'http://www.google.com/images.jpg'
+    }
+
+}


### PR DESCRIPTION
Hi Marc,

Here are the changes for the base url mapper. 

There are a few details on how to create a pulldown cdn in the plugin :
https://github.com/tomaslin/grails-cdn-resources/blob/master/README.md

New configuration parameters are

grails.resources.mappers.baseurl.enabled = true
grails.resources.mappers.baseurl.baseUrl = 'http://www.google.com/'
grails.resources.mappers.baseurl.moduleUrls = [ 'google' : 'http://www.google.com/apis', 'core' : 'http://subdomain.mysite.com' ]

The last one is for specifying individual modules per name.
