### PR TITLE
Implementation of GPRESOURCES-128

### DIFF
--- a/ResourcesGrailsPlugin.groovy
+++ b/ResourcesGrailsPlugin.groovy
@@ -108,7 +108,8 @@ class ResourcesGrailsPlugin {
         def declaredResFilter = [   
                 name:'DeclaredResourcesPluginFilter', 
                 filterClass:"org.grails.plugin.resource.ProcessingFilter",
-                urlPatterns:["/${getUriPrefix(application)}/*"]
+                urlPatterns:["/${getUriPrefix(application)}/*"],
+                dispatchers:['REQUEST', 'FORWARD']
         ]
         def adHocFilter = [   
             name:'AdHocResourcesPluginFilter', 

--- a/src/docs/guide/9. Configuration.gdoc
+++ b/src/docs/guide/9. Configuration.gdoc
@@ -79,3 +79,7 @@ Note that the value you provide *replaces* the default list supplied by the mapp
 h2. Disabling CSS rewriting: grails.resources.rewrite.css
 
 It is possible to turn off all CSS rewriting by setting this value to false. This is not recommended as it will usually break bundling unless all your links are relative and you don't have any mappers that move your resources relative to your CSS.
+
+h2. Using forward instead of redirect for adhoc filter: grails.resources.adhoc.forward
+
+The default behavior for ad-hoc filter is to use a 302 redirect to the requested resource. Enabling this flag will opt to use a server-side forward instead.

--- a/src/groovy/org/grails/plugin/resource/ResourceProcessor.groovy
+++ b/src/groovy/org/grails/plugin/resource/ResourceProcessor.groovy
@@ -241,12 +241,21 @@ class ResourceProcessor implements InitializingBean {
     void redirectToActualUrl(ResourceMeta res, request, response) {
         // Now redirect the client to the processed url
         // NOTE: only works for local resources
-        def u = request.contextPath+staticUrlPrefix+res.linkUrl
-        if (log.debugEnabled) {
-            log.debug "Redirecting ad-hoc resource ${request.requestURI} to $u which makes it UNCACHEABLE - declare this resource "+
-                "and use resourceLink/module tags to avoid redirects and enable client-side caching"
+        def u = staticUrlPrefix+res.linkUrl
+        if (config.adhoc?.forward) {
+            if (log.debugEnabled) {
+                log.debug "Forwarding ad-hoc resource ${request.requestURI} to $u - declare this resource "+
+                    "and use resourceLink/module tags to avoid spurious client-side caching"
+            }
+            request.getRequestDispatcher(u).forward(request, response)
+        } else {
+            u = request.contextPath + u
+            if (log.debugEnabled) {
+                log.debug "Redirecting ad-hoc resource ${request.requestURI} to $u which makes it UNCACHEABLE - declare this resource "+
+                    "and use resourceLink/module tags to avoid redirects and enable client-side caching"
+            }
+            response.sendRedirect(u)
         }
-        response.sendRedirect(u)
     }
     
     /**


### PR DESCRIPTION
Provide a config flag to use server-side forward instead of client-side redirect for legacy ad-hoc resources. Implements [GPRESOURCES-128](http://jira.grails.org/browse/GPRESOURCES-128).
