### PR TITLE
Add a log message for when resource mapper is done

### DIFF
--- a/src/groovy/org/grails/plugin/resource/ResourceProcessor.groovy
+++ b/src/groovy/org/grails/plugin/resource/ResourceProcessor.groovy
@@ -1021,6 +1021,7 @@ class ResourceProcessor implements InitializingBean {
             loadModules(reloadBatch)
             
             dumpStats()
+            log.info("Finished module definition reload")
         } finally {
             reloading = false
         }
@@ -1038,6 +1039,7 @@ class ResourceProcessor implements InitializingBean {
             loadResources(reloadBatch)
             
             dumpStats()
+            log.info("Finished changed file reload")
         } finally {
             reloading = false
         }
@@ -1057,6 +1059,7 @@ class ResourceProcessor implements InitializingBean {
             loadModules(reloadBatch)
             
             dumpStats()
+            log.info("Finished full reload")
         } finally {
             reloading = false
         }


### PR DESCRIPTION
There's already an info level log message for when resource mapping starts (whenever a file changes).  This pull request adds a one line log.info message for when resource mapping is finished.

This would be a big help for knowing when I can reload my browser.  I always end up hitting refresh a couple of times never sure if my latest changes are out there or not. 

Now I can just watch for this log message and then refresh after it's done, confident that the new code should be in my browser after I load.
