### PR TITLE
Fix problem where reloading fails for inline plugin resource

### DIFF
--- a/ResourcesGrailsPlugin.groovy
+++ b/ResourcesGrailsPlugin.groovy
@@ -182,8 +182,7 @@ class ResourcesGrailsPlugin {
     
     boolean isResourceWeShouldProcess(File file) {
         // Make windows filenams safe for matching
-        def baseDir = new File('.', 'web-app').canonicalPath+'/'
-        def fileName = file.canonicalPath.replaceAll('\\\\', '/').substring(baseDir.size())
+        def fileName = file.canonicalPath.replaceAll('\\\\', '/').replaceAll('^.*?/web-app/', '')
         boolean shouldProcess = !(RELOADABLE_RESOURCE_EXCLUDES.any { PATH_MATCHER.match(it, fileName ) })
         return shouldProcess
     }


### PR DESCRIPTION
The `isResourceWeShouldProcess` method assumes that any resource is in a sub-directory of the application's base directory. When using inline plugins this is probably not the case & hence the `substring` call failed with a `StringIndexOutOfBoundsException`. Since it looks like the plugin was just trying to get a file path relative to the `web-app` directory to see if it's in an exclude pattern list I've changed it to just strip anything up to and including `web-app/` from the canonical file path.
