### PR TITLE
Bug: tag attributes returned by getDefaultSettingsForURI are ignored.

### DIFF
--- a/src/groovy/org/grails/plugin/resource/ResourceModule.groovy
+++ b/src/groovy/org/grails/plugin/resource/ResourceModule.groovy
@@ -154,7 +154,7 @@ class ResourceModule {
                 resattrs[k] = v
             }
         }
-        r.tagAttributes = attrs?.clone()
+        r.tagAttributes = resattrs
         r.attributes.putAll(args)
         return r        
     }


### PR DESCRIPTION
Bug-fix required for the <strong>gsp-resources</strong> plugin.

The gsp-resources plugin overrides method getDefaultSettingsForURI, as it needs to strip off the '.gsp' from the URI before the resources plugin retrieves the default settings. It also needs to override the 'type' of the resource in the returned tag attributes.

However, with this bug in the resources plugin code, the returned tag attributes are ignored when constructing the resource module. I think this is just a small typo!
