### PR TITLE
Unit tests broken as they referenced non-existing file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,14 @@ plugin.xml
 *.zip
 dependencies.groovy
 target
+out
 /stacktrace.log
 /test-tmp/
 /src/docs/ref/Resources/
 grails-app/i18n/
+.idea
+.classpath
+.settings
+*.iml
+*.iws
+*.ipr

--- a/test/unit/org/grails/plugin/resource/BaseUrlResourceMapperSpec.groovy
+++ b/test/unit/org/grails/plugin/resource/BaseUrlResourceMapperSpec.groovy
@@ -1,7 +1,6 @@
 package org.grails.plugin.resource
 
 import grails.plugin.spock.UnitSpec
-import org.grails.plugin.resource.mapper.BaseUrlResourceMapper
 
 class BaseUrlResourceMapperSpec extends UnitSpec{
 

--- a/test/unit/org/grails/plugin/resource/ResourceTagLibTests.groovy
+++ b/test/unit/org/grails/plugin/resource/ResourceTagLibTests.groovy
@@ -1,11 +1,10 @@
 package org.grails.plugin.resource
 
-import grails.test.*
-
 import org.junit.Before
 
 import org.grails.plugin.resource.util.HalfBakedLegacyLinkGenerator
 import org.codehaus.groovy.grails.web.taglib.exceptions.GrailsTagException
+import grails.test.mixin.TestFor
 
 @TestFor(ResourceTagLib)
 class ResourceTagLibTests {


### PR DESCRIPTION
The unit tests were breaking due to invalid imports. This request fixes these issues. 
