### PR TITLE
GPRESOURCES-177: Give module DSL closures access to grailsApplication

### DIFF
--- a/src/groovy/org/grails/plugin/resource/module/ModuleDeclarationsFactory.groovy
+++ b/src/groovy/org/grails/plugin/resource/module/ModuleDeclarationsFactory.groovy
@@ -24,6 +24,9 @@ class ModuleDeclarationsFactory {
     static Map<String,Closure> getModuleDeclarations(grailsApplication, String environment = Environment.current.name) {
         
         def slurper = new ConfigSlurper(environment)
+
+        // give module DSL closures access to grailsApplication
+        slurper.setBinding([grailsApplication: grailsApplication])
         
         // order so we are guaranteed of consistency
         def orderedResourceClasses = grailsApplication.resourcesClasses.sort { it.name }


### PR DESCRIPTION
This pull request includes a implementation of GPRESOURCES-177: "Make GrailsApplication available to module DSL closures"
