### PR TITLE
Ignoring Eclipse and GGTS settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ target
 /test-tmp/
 /src/docs/ref/Resources/
 grails-app/i18n/
+target-eclipse/
+.settings/
+.project
+.classpath


### PR DESCRIPTION
This patch add lines to the .gitignore to ignore files and directories created by GGTS which should be ignored and not included in the public repository.
