### PR TITLE
Corrected r:require example

### DIFF
--- a/src/docs/guide/4.1 Linking to CSS, JavaScript etc..gdoc
+++ b/src/docs/guide/4.1 Linking to CSS, JavaScript etc..gdoc
@@ -25,7 +25,7 @@ Example GSP page:
 <html>
    <head>
       <meta name="layout" content="main"/>
-      <r:require module="jquery-ui, blueprint"/>
+      <r:require modules="jquery-ui, blueprint"/>
       <g:if test="${customerBranding}">
           <r:require module="theme_${customer.theme}"/>
       </g:if>


### PR DESCRIPTION
The r:require example in section 4.1 requires multiple modules so it should use the 'modules' attribute rather than 'module'.
