### PR TITLE
Allow for scheme-less absolute URIs

### DIFF
--- a/grails-app/taglib/org/grails/plugin/resource/ResourceTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/resource/ResourceTagLib.groovy
@@ -549,7 +549,7 @@ class ResourceTagLib {
         def ctxPath = request.contextPath
 
         def uri = attrs.remove('uri')
-        def abs = uri?.indexOf('://') >= 0
+        def abs = uri?.indexOf('://') >= 0 || uri?.startsWith('//') // allow for scheme-less urls
 
         if (!uri) {
             // use the link generator to avoid stack overflow calling back into us


### PR DESCRIPTION
Add check for scheme-less absolute URIs (e.g. //mycdn.myhost.com/images/myimg.png)