### PR TITLE
GPRESOURCES-212 - tag r:style (like the r:script tag)

### DIFF
--- a/grails-app/taglib/org/grails/plugin/resource/ResourceTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/resource/ResourceTagLib.groovy
@@ -452,8 +452,13 @@ class ResourceTagLib {
      * @todo Later, we implement ESP hooks here and add scope="user" or scope="shared"
      */
     def script = { attrs, body ->
-        def dispos = attrs.remove('disposition') ?: 'defer'
-        stashPageFragment('script', dispos, body())
+        final String disposition = attrs.remove('disposition') ?: 'defer'
+        stashPageFragment('script', disposition, body())
+    }
+
+    def style = { attributes, body ->
+        final String disposition = attributes.remove("disposition") ?: DispositionsUtils.DISPOSITION_HEAD
+        stashPageFragment("style", disposition, body())
     }
 
     def stash = { attrs, body ->

--- a/src/docs/ref/Tags/style.gdoc
+++ b/src/docs/ref/Tags/style.gdoc
@@ -1,0 +1,30 @@
+h1. r:style Tag
+
+Using this tag you can write "inline" CSS anywhere in your GSP (providing you use Sitemesh layouts), which will be placed at the used disposition. The disposition "head" is used as default.
+
+The code is executed after all the other resources in the given disposition have been included, so you can easily stack up little fragments that set up your UI elements or perform other functions.
+
+Assuming a Sitemesh layout that calls <r:layoutResources/> at the correct times, the following causes alerts to occur when head and page body load:
+
+{code:xml}
+<html>
+   <head>
+      <meta name="layout" content="main"/>
+      <r:require modules="jquery-ui, blueprint"/>
+      <r:require module="single-module"/>
+
+      <r:style>
+         p {
+            color: ${['blue', 'green', 'red', 'yellow'][new Random().nextInt(4)]} !important;
+         }
+      </r:style>
+   </head>
+   <body>
+      <p>Text in a random color.</p>
+   </body>
+</html>
+{code}
+
+h2. Attributes
+
+* disposition - Optional. The disposition name of the code. Defaults to "head", but can be any other disposition like "defer".

--- a/test/integration/org/grails/plugin/resource/ResourceTagLibIntegTests.groovy
+++ b/test/integration/org/grails/plugin/resource/ResourceTagLibIntegTests.groovy
@@ -140,4 +140,32 @@ class ResourceTagLibIntegTests extends GroovyPagesTestCase {
 
         assertEquals 1, result.count("/static/_bundle-bundle_GPRESOURCES-210_module_A_duplicate_includes_check.js")
     }
+
+    def testStyleTagWithDefaultDisposition() {
+        String template = '''
+            <r:style>
+            /* stashed styles */
+            </r:style>
+
+            <r:layoutResources disposition="head"/>
+        '''
+
+        String result = applyTemplate(template)
+
+        assertTrue result ==~ /\s*<style type="text\/css">\s*\/\* stashed styles \*\/\s*<\/style>\s*/
+    }
+
+    def testStyleTagWithCustomDisposition() {
+        String template = '''
+            <r:style disposition="custom_disposition">
+            /* stashed styles */
+            </r:style>
+
+            <r:layoutResources disposition="custom_disposition"/>
+        '''
+
+        String result = applyTemplate(template)
+
+        assertTrue result ==~ /\s*<style type="text\/css">\s*\/\* stashed styles \*\/\s*<\/style>\s*/
+    }
 }


### PR DESCRIPTION
Provides a new tag r:style like the r:script tag, which uses the disposition "head" as default. The pull requests consists of the implementation, integration tests as well as the documentation for the new tag (ticket: [GPRESOURCES-212](http://jira.grails.org/browse/GPRESOURCES-212)).
