### PR TITLE
GPRESOURCES-213 - allow custom writers/types for the stashing feature

### DIFF
--- a/grails-app/taglib/org/grails/plugin/resource/ResourceTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugin/resource/ResourceTagLib.groovy
@@ -20,7 +20,7 @@ class ResourceTagLib {
     static REQ_ATTR_PREFIX_PAGE_FRAGMENTS = 'resources.plugin.page.fragments'
     static REQ_ATTR_PREFIX_AUTO_DISPOSITION = 'resources.plugin.auto.disposition'
     
-    static stashWriters = [
+    static STASH_WRITERS = [
         'script': { out, stash ->
             out << "<script type=\"text/javascript\">"
             for (s in stash) {
@@ -353,9 +353,8 @@ class ResourceTagLib {
         "${REQ_ATTR_PREFIX_PAGE_FRAGMENTS}:${type}:${disposition}"
     }
     
-    private consumePageFragments(String type, String disposition) {
-        def fraggles = request[ResourceTagLib.makePageFragmentKey(type, disposition)] ?: Collections.EMPTY_LIST
-        return fraggles
+    private List consumePageFragments(String type, String disposition) {
+        return (List) request[ResourceTagLib.makePageFragmentKey(type, disposition)] ?: Collections.EMPTY_LIST
     }
     
     private static String makeAutoDispositionKey( String disposition) {
@@ -437,12 +436,12 @@ class ResourceTagLib {
         DispositionsUtils.doneDispositionResources(request, dispositionToRender)
     }
 
-    private layoutPageStash(String disposition) {
-        def fragmentTypes = ['script', 'style']
-        for (t in fragmentTypes) {
-            def stash = consumePageFragments(t, disposition)
+    private layoutPageStash(final String disposition) {
+        final Set<String> fragmentTypes = STASH_WRITERS.keySet()
+        for (final String type in fragmentTypes) {
+            final List stash = consumePageFragments(type, disposition)
             if (stash) {
-                stashWriters[t](out, stash)
+                STASH_WRITERS[type](out, stash)
             }
         }
     }

--- a/test/integration/org/grails/plugin/resource/ResourceTagLibIntegTests.groovy
+++ b/test/integration/org/grails/plugin/resource/ResourceTagLibIntegTests.groovy
@@ -140,4 +140,94 @@ class ResourceTagLibIntegTests extends GroovyPagesTestCase {
 
         assertEquals 1, result.count("/static/_bundle-bundle_GPRESOURCES-210_module_A_duplicate_includes_check.js")
     }
+
+    void testStashOfTypeScript() {
+        String template = '''
+            <r:stash type="script" disposition="script_stash_disposition">script stash</r:stash>
+            <r:layoutResources disposition="script_stash_disposition"/>
+        '''
+
+        String result = applyTemplate(template)
+
+        assertEquals "<script type=\"text/javascript\">script stash</script>", result.trim()
+    }
+
+    void testStashOfTypeScriptWithMultipleEntries() {
+        String template = '''
+            <r:stash type="script" disposition="script_stash_disposition">script stash1;</r:stash>
+            <r:stash type="script" disposition="script_stash_disposition">script stash2;</r:stash>
+            <r:layoutResources disposition="script_stash_disposition"/>
+        '''
+
+        String result = applyTemplate(template)
+
+        assertEquals "<script type=\"text/javascript\">script stash1;script stash2;</script>", result.trim()
+    }
+
+    void testStashOfTypeStyle() {
+        String template = '''
+            <r:stash type="style" disposition="style_stash_disposition">style stash</r:stash>
+            <r:layoutResources disposition="style_stash_disposition"/>
+        '''
+
+        String result = applyTemplate(template)
+
+        assertEquals "<style type=\"text/css\">style stash</style>", result.trim()
+    }
+
+    void testStashOfTypeStyleWithMultipleEntries() {
+        String template = '''
+            <r:stash type="style" disposition="style_stash_disposition">style stash1;</r:stash>
+            <r:stash type="style" disposition="style_stash_disposition">style stash2;</r:stash>
+            <r:layoutResources disposition="style_stash_disposition"/>
+        '''
+
+        String result = applyTemplate(template)
+
+        assertEquals "<style type=\"text/css\">style stash1;style stash2;</style>", result.trim()
+    }
+
+    void testStashOfACustomType() {
+        String type = "custom-stash"
+        ResourceTagLib.STASH_WRITERS[type] = { out, stash ->
+            out << "<ul>"
+            for (s in stash) {
+                out << "<li>" << s << "</li>"
+            }
+            out << "</ul>"
+        }
+        String template = """
+            <r:stash type="${type}" disposition="${type}_stash_disposition">${type} stash</r:stash>
+            <r:layoutResources disposition="${type}_stash_disposition"/>
+        """
+
+        String result = applyTemplate(template)
+        // cleanup
+        ResourceTagLib.STASH_WRITERS.remove(type)
+
+        assertEquals "<ul><li>custom-stash stash</li></ul>", result.trim()
+    }
+
+    void testStashOfACustomTypeWithMultipleEntries() {
+        String type = "custom-stash"
+        ResourceTagLib.STASH_WRITERS[type] = { out, stash ->
+            out << "<ul>"
+            for (s in stash) {
+                out << "<li>" << s << "</li>"
+            }
+            out << "</ul>"
+        }
+        String template = """
+            <r:stash type="${type}" disposition="${type}_stash_disposition">${type} stash1;</r:stash>
+            <r:stash type="${type}" disposition="${type}_stash_disposition">${type} stash2;</r:stash>
+            <r:layoutResources disposition="${type}_stash_disposition"/>
+        """
+
+        String result = applyTemplate(template)
+        // cleanup
+        ResourceTagLib.STASH_WRITERS.remove(type)
+
+        assertEquals "<ul><li>custom-stash stash1;</li><li>custom-stash stash2;</li></ul>", result.trim()
+    }
+
 }


### PR DESCRIPTION
Contains the implementation as well as integration tests for ticket [GPRESOURCES-213](http://jira.grails.org/browse/GPRESOURCES-213).

After merging, you can use custom stash types and writers, it'll remove the current limitation via the hardcoded set of types (script and style only).
