### PR TITLE
GPRESOURCES-170 - interpret "server-relative" URLs in CSS files as context-relative URLs

### DIFF
--- a/src/groovy/org/grails/plugin/resource/URLUtils.groovy
+++ b/src/groovy/org/grails/plugin/resource/URLUtils.groovy
@@ -25,8 +25,7 @@ class URLUtils {
      * the file containing the url is moved
      */
     static Boolean isRelativeURL(url) {
-        !url.startsWith('/') && 
-        !url.startsWith('data:') && 
+        !url.startsWith('data:') &&
         !url.startsWith('#') && 
         !(url.indexOf('://') >= 0)
     }

--- a/test/unit/org/grails/plugin/resource/CSSPreprocessorResourceMapperTests.groovy
+++ b/test/unit/org/grails/plugin/resource/CSSPreprocessorResourceMapperTests.groovy
@@ -48,7 +48,7 @@ class CSSPreprocessorResourceMapperTests extends GrailsUnitTestCase {
         def expected = """
 .bg1 { background: url(resource:/images/theme/bg1.png) }
 .bg2 { background: url(resource:/css/images/bg2.png) }
-.bg3 { background: url(/images/bg3.png) }
+.bg3 { background: url(resource:/images/bg3.png) }
 .bg4 { background: url(resource:/css/bg4.png) }
 .bg5 { background: url(http://google.com/images/bg5.png) }
 """

--- a/test/unit/org/grails/plugin/resource/URLUtilsTests.groovy
+++ b/test/unit/org/grails/plugin/resource/URLUtilsTests.groovy
@@ -1,8 +1,9 @@
 package org.grails.plugin.resource
 
-import grails.test.*
+import grails.test.GrailsUnitTestCase
 
 class URLUtilsTests extends GrailsUnitTestCase {
+
     void testRelativeCSSUris() {
         assertEquals "images/bg_fade.png", URLUtils.relativeURI('css/main.css', '../images/bg_fade.png')
         assertEquals "/images/bg_fade.png", URLUtils.relativeURI('/css/main.css', '../images/bg_fade.png')
@@ -17,4 +18,29 @@ class URLUtilsTests extends GrailsUnitTestCase {
         assertEquals "/bg_fade.png", URLUtils.relativeURI('/css/main.css', '/bg_fade.png')
         assertEquals "http://somewhere.com/images/x.png", URLUtils.relativeURI('css/main.css', 'http://somewhere.com/images/x.png')
     }
+
+    void testIsRelativeForServerRelativeUrls() {
+        assertTrue URLUtils.isRelativeURL("/server/relative")
+    }
+
+    void testIsRelativeForRelativeToCurrentPath() {
+        assertTrue URLUtils.isRelativeURL("relative/to/current/path")
+    }
+
+    void testIsRelativeForRelativeToCurrentPathViaParent() {
+        assertTrue URLUtils.isRelativeURL("../relative/to/current/path")
+    }
+
+    void testIsRelativeForDataUrls() {
+        assertFalse URLUtils.isRelativeURL("data:xyz")
+    }
+
+    void testIsRelativeForPageFragments() {
+        assertFalse URLUtils.isRelativeURL("#fragment_only")
+    }
+
+    void testIsRelativeForAbsoluteUrls() {
+        assertFalse URLUtils.isRelativeURL("http://www.example.org/absolute/path")
+    }
+
 }


### PR DESCRIPTION
As stated in [GPRESOURCES-170](http://jira.grails.org/browse/GPRESOURCES-170), there are two possibile interpretations of URLs starting with a slash. It might be a server-relative URL containing the context path (if there is any), or it might be a context-relative URL, which doesn't contain the context.

For the 1st case, those URLs might get broken, if the application uses a different configuration value for the context or was deployed under a different context (i.e. via a different WAR file name).

For the 2nd case, URLs would be broken, if the application is not deployed at the root context.

Because of these reasons, such references shouldn't be used.

For the case that they have been used, this patch will now interpret such references as context-relative and will therefore mark and process them.

All unit tests related to it have been adjusted and some additional ones for the URLUtils have been provided as well.
