### PR TITLE
Fixed strict=false problem

### DIFF
--- a/src/groovy/org/grails/plugin/resource/ResourceProcessor.groovy
+++ b/src/groovy/org/grails/plugin/resource/ResourceProcessor.groovy
@@ -1088,7 +1088,9 @@ class ResourceProcessor implements InitializingBean {
     void addModuleDispositionsToRequest(request, String moduleName) {
         log.debug "Adding module dispositions for module [${moduleName}]"
 
-        def moduleNamesRequired = getAllModuleNamesRequired([moduleName])
+        Boolean mandatory = request.resourceModuleTracker[moduleName] != Boolean.FALSE
+        def moduleNamesRequired = getAllModuleNamesRequired(["$moduleName":mandatory])
+
         moduleNamesRequired.each { name ->
             def module = modulesByName[name]
             if (module) {


### PR DESCRIPTION
The strict argument on the r:require tag doesn't work anymore. This simple fix should patch it.
