### PR TITLE
fix NPE in onChange when in forked execution

### DIFF
--- a/ResourcesGrailsPlugin.groovy
+++ b/ResourcesGrailsPlugin.groovy
@@ -197,22 +197,24 @@ class ResourcesGrailsPlugin {
     }
     
     def onChange = { event ->
-        if (event.source instanceof FileSystemResource) {
-            if (isResourceWeShouldProcess(event.source.file)) {
-                log.info("Scheduling reload of resource files due to change of file $event.source.file")
-                triggerReload {
-                    event.application.mainContext.grailsResourceProcessor.reloadChangedFiles()
+        if (event.application?.mainContext?.grailsResourceProcessor) {
+            if (event.source instanceof FileSystemResource) {
+                if (isResourceWeShouldProcess(event.source.file)) {
+                    log.info("Scheduling reload of resource files due to change of file $event.source.file")
+                    triggerReload {
+                        event.application.mainContext.grailsResourceProcessor.reloadChangedFiles()
+                    }
                 }
-            }
-        } else if (handleChange(application, event, getResourceMapperArtefactHandler().TYPE, log)) {
-            log.info("Scheduling reload of mappers due to change of $event.source.name")
-            triggerReload {
-                event.application.mainContext.grailsResourceProcessor.reloadMappers()
-            }
-        } else if (handleChange(application, event, getResourcesArtefactHandler().TYPE, log)) {
-            log.info("Scheduling reload of modules due to change of $event.source.name")
-            triggerReload {
-                event.application.mainContext.grailsResourceProcessor.reloadModules()
+            } else if (handleChange(application, event, getResourceMapperArtefactHandler().TYPE, log)) {
+                log.info("Scheduling reload of mappers due to change of $event.source.name")
+                triggerReload {
+                    event.application.mainContext.grailsResourceProcessor.reloadMappers()
+                }
+            } else if (handleChange(application, event, getResourcesArtefactHandler().TYPE, log)) {
+                log.info("Scheduling reload of modules due to change of $event.source.name")
+                triggerReload {
+                    event.application.mainContext.grailsResourceProcessor.reloadModules()
+                }
             }
         }
     }


### PR DESCRIPTION
Fix for http://jira.grails.org/browse/GRAILS-10880
This is caused by forked execution: there are two parallel onChange events fired, one in the app that runs successfully, and one in the starter jvm that fails because there is no spring context.
