### PR TITLE
Fix resources 267

### DIFF
--- a/src/groovy/org/grails/plugin/resource/ResourceMeta.groovy
+++ b/src/groovy/org/grails/plugin/resource/ResourceMeta.groovy
@@ -416,7 +416,7 @@ class ResourceMeta {
      * All resource URLs must be app-relative with no ../ or ./
      */
     String relativeTo(ResourceMeta base) {
-        if (base.is(this)){
+        if (base.is(this)) {
             return actualUrl
         }
         if (actualAbsolute) {

--- a/src/groovy/org/grails/plugin/resource/ResourceMeta.groovy
+++ b/src/groovy/org/grails/plugin/resource/ResourceMeta.groovy
@@ -373,7 +373,7 @@ class ResourceMeta {
     
     String getActualUrlParent() {
         def lastSlash = actualUrl.lastIndexOf('/')
-        if (lastSlash >= 0) {
+        if (lastSlash > 0) {
             return actualUrl[0..lastSlash-1]
         } else {
             return ''
@@ -416,6 +416,9 @@ class ResourceMeta {
      * All resource URLs must be app-relative with no ../ or ./
      */
     String relativeTo(ResourceMeta base) {
+        if (base.is(this)){
+            return actualUrl
+        }
         if (actualAbsolute) {
             return actualUrl
         }


### PR DESCRIPTION
a small inquiery should that the method evaluates 'this' and 'base' actually tries to work when actually 'this' IS 'base'
adding this condition at the beginning of the method fixes things:
if (base.is(this))
{ return actualUrl }
Also,
the method getActualUrlParent has a problem:
when evaluating apath starting with a slash (like '/mydir') it will return the complete string as a parent. this is due to the fact that the slash index is 0, and the substring 0..-1 means 'entire string' in groovy